### PR TITLE
Fixes for #8 & #9

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -24,6 +24,10 @@ if ! [ -x "$(command -v jq)" ]; then
   echo "${ERROR}Error: jq is not installed.${RESET}" >&2
   exit 1
 fi
+if ! [ -x "$(command -v wget)" ]; then
+  echo "${ERROR}Error: wget is not installed.${RESET}" >&2
+  exit 1
+fi
 
 observability=false
 shutdown=false
@@ -133,8 +137,8 @@ if [ ! -f ./transformed_data.json ]; then
       _jq() {
        echo ${my_line} | jq -r ${1}
       }
-     echo { \"index\" : {\"_id\" : \"$(_id)\"}}
-     echo $(_jq '.')
+     echo { \"index\" : {\"_id\" : \"$(_id)\"}} >> ${output}
+     echo $(_jq '.') >> ${output}
   done
 fi
 


### PR DESCRIPTION
This PR is meant to fix https://github.com/querqy/chorus-elasticsearch-edition/issues/8 & https://github.com/querqy/chorus-elasticsearch-edition/issues/9

Issues both affected the `quickstart.sh` script:
- product data is now written to a file not dumped to the console.
- pre-flight check for wget is now included.