### PR TITLE
Bump quepid remove redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ icecat-products-w_price-19k-20201127.tar.gz
 icecat-products-w_price-19k-20201127.json
 *.bu
 rre/target
+*.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,15 +50,9 @@ services:
     ports:
       - 4000:3000
 
-  redis:
-    container_name: redis
-    image: redis:6.2.6-alpine
-    ports:
-      - 6379:6379
-
   quepid:
     container_name: quepid
-    image: o19s/quepid:6.10.1
+    image: o19s/quepid:6.11.0
     ports:
       - 3000:3000
     environment:
@@ -66,7 +60,6 @@ services:
       - RACK_ENV=production
       - RAILS_ENV=production
       - DATABASE_URL=mysql2://root:password@mysql:3306/quepid
-      - REDIS_URL=redis://redis:6379/1
       - FORCE_SSL=false
       - MAX_THREADS=2
       - WEB_CONCURRENCY=2
@@ -84,7 +77,6 @@ services:
       - SIGNUP_ENABLED=true
     links:
       - mysql
-      - redis
 
   smui:
     container_name: smui


### PR DESCRIPTION
Redis is only used when Quepid is set up with GA tracking, and we dont' do that in this reference impl.